### PR TITLE
Fix throwing out bug (#1)

### DIFF
--- a/gamemode/sh_inventory.lua
+++ b/gamemode/sh_inventory.lua
@@ -75,7 +75,7 @@ if( CLIENT ) then
 	
 	local function nRemoveItem( len )
 		
-		local k = net.ReadUInt( 24 );
+		local k = net.ReadFloat();
 		
 		LocalPlayer():RemoveItem( k );
 		
@@ -385,7 +385,7 @@ function meta:ThrowOutItem( k )
 		table.remove( self.Inventory, k );
 		
 		net.Start( "nRemoveItem" );
-			net.WriteUInt( k, 32 );
+			net.WriteFloat( k );
 			net.WriteBit( true );
 		net.SendToServer();
 		

--- a/gamemode/sh_inventory.lua
+++ b/gamemode/sh_inventory.lua
@@ -102,7 +102,7 @@ else
 	
 	local function nRemoveItem( len, ply )
 		
-		local k = net.ReadUInt( 24 );
+		local k = net.ReadFloat();
 		local s = net.ReadBit();
 		
 		ply:RemoveItem( k, s );


### PR DESCRIPTION
This commit fixes the throwing out issue (#1) I made about a week ago. This might be out of line with some of the rest of the code which uses UInt instead of Floats, but for some reason, this works. I didn't do much testing as to why this works and UInt doesn't. This issue is pretty annoying as the UI doesn't correctly recognise that you've thrown out just that one item.

If you don't want to merge this because it uses Float instead of UInt, let me know and I will probably look into it further.